### PR TITLE
Change tag in git clone, N.2.5.1.0 -> N.2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN echo "deb https://packages.erlang-solutions.com/ubuntu focal contrib" | tee 
 RUN apt update
 RUN apt install -y erlang
 
-RUN cd /tmp; git clone --recursive --depth 1 --branch N.2.5.1.0 https://github.com/ArweaveTeam/arweave.git
+RUN cd /tmp; git clone --recursive --depth 1 --branch N.2.5.3 https://github.com/ArweaveTeam/arweave.git
 RUN cd /tmp/arweave; ./rebar3 as prod tar
-RUN cd /app; tar -zxvf /tmp/arweave/_build/prod/rel/arweave/arweave-2.5.1.0.tar.gz
+RUN cd /app; tar -zxvf /tmp/arweave/_build/prod/rel/arweave/arweave-2.5.3.tar.gz
 
 RUN ulimit -n 65535
 


### PR DESCRIPTION
Hi Rafael, I am currently trying to run your docker on my UNRAID, but I am getting the following error

![image](https://user-images.githubusercontent.com/12521836/197574243-1fb3e134-9a39-48c1-a7a1-692476a813de.png)

I asked the question about the Arweave mining discord.
https://discord.gg/bm9v2DtAa7

and the first thing they identified is that the version of the miner is outdated

Thank you very much for creating the Docker.
